### PR TITLE
Prepend Email Addresses with `mailto:`

### DIFF
--- a/src/components/ProfileCard.vue
+++ b/src/components/ProfileCard.vue
@@ -31,6 +31,9 @@ export default {
         image = linkedin
       } else if (link === 'email') {
         image = email
+        if (!this.links[link].startsWith('mailto:')) {
+          this.links[link] = 'mailto:' + this.links[link]
+        }
       }
       socials.push({ link: this.links[link], image: image })
     }


### PR DESCRIPTION
Many emails in our data JSON do not start with `mailto:`, so they are
made relative links. For example `me@example.com` becomes
`http://codethechange.stanford.edu/me@example.com`. To fix this, we
add `mailto:` to the start of any email address that doesn't already
have it.

Resolves #22