### PR TITLE
Add Link to Join Mailing List

### DIFF
--- a/src/views/Join.vue
+++ b/src/views/Join.vue
@@ -5,7 +5,9 @@
         <div class = "header-group">
             <h1 class = "header-title">Change the world and build projects with us.</h1>
             <div class = "cta-button">
-                <a href="https://codethechange.typeform.com/to/w7qJSt" target="_blank"><h3> APPLY </h3></a>
+                <a href="https://codethechange.typeform.com/to/w7qJSt"
+                  target="_blank"
+                ><h3> JOIN </h3></a>
                 <div id = "button-arrow">  </div>
             </div>
         </div>
@@ -46,9 +48,12 @@
     </div>
 
     <div class = "cta">
-        <h1> Ready to jump in?  Apply today. </h1>
+        <h1> Not ready to join yet? Sign up for our mailing list!</h1>
         <div class = "cta-button" id ="footer-cta">
-             <a href="https://codethechange.typeform.com/to/w7qJSt" target="_blank"><h3> Apply </h3></a>
+             <a
+               href="https://mailman.stanford.edu/mailman/listinfo/codethechange_general"
+               target="_blank"
+             ><h3> Sign Up </h3></a>
         </div>
     </div>
 </div>

--- a/src/views/Join.vue
+++ b/src/views/Join.vue
@@ -48,7 +48,7 @@
     </div>
 
     <div class = "cta">
-        <h1> Not ready to join yet? Sign up for our mailing list!</h1>
+        <h1> Want to stay in the loop? Sign up for our mailing list!</h1>
         <div class = "cta-button" id ="footer-cta">
              <a
                href="https://mailman.stanford.edu/mailman/listinfo/codethechange_general"


### PR DESCRIPTION
On the Join page, add a link to let people add themselves to the mailing
list. We would prefer of course that people fill out the full survey at
the top of the page, but the mailing list is for people who aren't ready
to fill that out but still want information on meetings, events, etc.

Resolves #17