### PR TITLE
Update Partner Criteria Link Style to Match Navbar

### DIFF
--- a/src/views/Partner.vue
+++ b/src/views/Partner.vue
@@ -77,7 +77,8 @@
             You must be a nonprofit or low-resourced social venture that
             needs volunteer support for an impactful computer science
             project. For details on how we evaluate projects, see our
-            <router-link class="small-link-text" to="/partner_criteria">
+            <router-link class="small-link-text color-change"
+                         to="/partner_criteria">
               partner criteria
             </router-link>.
           </div>
@@ -178,6 +179,14 @@ export default {
   letter-spacing: normal;
   color: #ffffff;
 
+}
+
+.color-change {
+  color: #ffffff;
+  &:hover {
+    text-decoration: inherit;
+    color: $accent-light;
+  }
 }
 
 .container{


### PR DESCRIPTION
Style the partner criteria link in `Partner.vue` to match the links in
the top navbar. This uses the same `color-change` class and style as the
navbar links. Resolves #29.