### PR TITLE
Explain Membership/Involvement Types

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -7,6 +7,7 @@ import Projects from './views/Projects.vue'
 import Join from './views/Join.vue'
 import ProjectProfile from './views/ProjectProfile.vue'
 import PartnerCriteria from './views/PartnerCriteria.vue'
+import WaysToContribute from './views/WaysToContribute.vue'
 
 Vue.use(Router)
 
@@ -46,6 +47,11 @@ export default new Router({
       path: '/partner_criteria',
       name: 'partner_criteria',
       component: PartnerCriteria
+    },
+    {
+      path: '/ways_to_contribute',
+      name: 'ways_to_contribute',
+      component: WaysToContribute
     }
   ]
 })

--- a/src/views/WaysToContribute.vue
+++ b/src/views/WaysToContribute.vue
@@ -52,7 +52,7 @@ export default {
   },
   methods: {
   },
-  name: 'ProjectCriteria',
+  name: 'WaysToContribute',
   components: {
     VueMarkdown
   }

--- a/src/views/WaysToContribute.vue
+++ b/src/views/WaysToContribute.vue
@@ -1,0 +1,100 @@
+<template>
+  <div class="container-fluid">
+    <div class="intro">
+      <h1 id="hook">Ways to Contribute</h1>
+      <p class = 'hook-sub'>
+        Want to help with our projects? We want to support you whether
+        you can contribute an hour a week or ten.
+      </p>
+    </div>
+    <div id="white">
+      <div id="content">
+        <!-- Line breaks in the markdown are treated literally -->
+        <vue-markdown>
+# Contribute Independently
+
+We welcome independent contributions, whether you are exploring a project through starter issues or have too tight a schedule to contribute regularly. There are no pre-requisites for this kind of contribution.
+
+If you run into problems, please reach out to the team whose project you are working on via email or Slack. If a team has a dedicated Slack channel for new members, e.g. `#oppia-new`, that's a great place to ask.
+
+Your contributions will be credited to you in the project's normal manner (e.g. public GitHub commits, an `AUTHORS` file, etc.).
+
+# Join a Team
+
+If you're ready to commit more time to a project you're interested in, consider joining as a member! First, we ask that you complete 2 starter tasks and have your changes accepted by the partner organization. From then on, we expect you to be engaged with the project via contributions, email, attending meetings, Slack, etc. weekly. If we don't see any engagement for 14 days without explanation, we may remove you.
+
+As a member of the team, your team's Slack channel is a great place to ask questions and stay up-to-date with your teammates work. Team meetings are also great ways to get help, as is/are your team lead(s).
+
+If you like, we'll add your photo and contact information to our website to showcase your contributions. As a member, you are considered an official member of the VSO, so we'll add you on OrgSync. Your contributions will also be credited to you in the project's normal manner, and your increased contributions may earn you further recognition from the partner, e.g. joining their GitHub organization.
+
+# Lead a Team
+
+Good team leads are indispensible to the success of our projects. If you're interested in helping in this way, please reach out to the club leadership!
+
+# Lead the Club
+
+If you are interested in being a club officer, let us know! We hold elections each spring. Our officers select team leads and support teams by acquiring funding, finding partners, marketing projects, and much more.
+        </vue-markdown>
+
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import VueMarkdown from 'vue-markdown'
+
+export default {
+  data: function () {
+    return {}
+  },
+  computed: {
+  },
+  methods: {
+  },
+  name: 'ProjectCriteria',
+  components: {
+    VueMarkdown
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import '../theme.scss';
+
+.container-fluid {
+  padding: 0;
+}
+
+.intro {
+  padding: 50px 50px 50px 250px;
+  @media only screen and (max-width: 700px) {
+    padding: 20px;
+  }
+}
+
+#white {
+    background-color: #ffffff;
+    display: flex;
+    justify-content: center;
+}
+
+#content {
+    padding: 60px;
+    max-width: 900px;
+    color: #5e5e5e;
+    font-family: 'Open Sans';
+    font-size: 1em;
+    font-style: normal;
+    font-stretch: normal;
+}
+
+#hook{
+  font-size: 5em;
+}
+
+.hook-sub{
+  font-size: 1.2em;
+  padding-top: 2.5vh;
+}
+</style>


### PR DESCRIPTION
Creates a page that describes the ways to get involved and the levels of contribution. This helps  set expectations for the various contribution types, notably the difference between being a member and just contributing. This page isn't linked-to from anywhere in the site yet pending creation of a page for current members.

Resolves #40.
