### PR TITLE
Remove Sam from Leadership

### DIFF
--- a/src/data/people.json
+++ b/src/data/people.json
@@ -328,7 +328,6 @@
             "github": "https://github.com/ssilverst",
             "linkedin": "www.linkedin.com/in/samantha-silverstein-701b5b15a"
         },
-        "leadership": true,
         "name": "Sam Silverstein",
         "role": "Service Coordinator"
     },


### PR DESCRIPTION
Sam Silverstein decided she does not have the capacity to be on leadership this year. This is just to update the website accordingly: new members have put her as the Cardinal Commitment mentor.