### PR TITLE
Remove HTML Loader

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -8,12 +8,5 @@ module.exports = {
     host: '0.0.0.0',
     hot: true,
     disableHostCheck: true
-  },
-  chainWebpack: config => {
-    config.module
-      .rule('html')
-      .test(/\.html$/)
-      .use('html-loader')
-      .loader('html-loader')
   }
 }


### PR DESCRIPTION
I accidentally merged in unnecessary loader configuration for when we thought that we wanted to load our guides HTML build via webpack.