### PR TITLE
Remove Defunct 123metrics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,9 +8,6 @@
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"/>
     <title>Code the Change</title>
   </head>
-  <script type="text/javascript"
-          src="https://api.123metrics.com/123metrics.js" async defer
-  ></script>
   <body>
     <noscript>
       <strong>We're sorry but www doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>


### PR DESCRIPTION
123metrics no longer appears to be operating, so we should not be using it in our website. Also, there's no SRI in that script import, which is bad.